### PR TITLE
Fix for dividing polygons with negative coordinates

### DIFF
--- a/polygondivider.py
+++ b/polygondivider.py
@@ -322,7 +322,7 @@ class ExampleWorker(AbstractWorker):
 				if horizontal:	## cut from the bottom
 
 					# left is the top one
-					maxy = 0
+					maxy = float('-inf')
 					for i in range(len(polys)):
 						p = polys[i].boundingBox().yMaximum()
 						if p > maxy:

--- a/polygondivider.py
+++ b/polygondivider.py
@@ -345,7 +345,7 @@ class ExampleWorker(AbstractWorker):
 				else:	## cutting from the left
 	
 					# left is the rightest one
-					maxx = 0
+					maxx = float('-inf')
 					for i in range(len(polys)):
 						p = polys[i].boundingBox().xMaximum()
 						if p > maxx:
@@ -379,7 +379,7 @@ class ExampleWorker(AbstractWorker):
 					left = polys.pop(minyi)
 	
 					# right is the top one
-					maxy = 0
+					maxy = float('-inf')
 					for i in range(len(polys)):
 						p = polys[i].boundingBox().yMaximum()
 						if p > maxy:

--- a/polygondivider.py
+++ b/polygondivider.py
@@ -402,7 +402,7 @@ class ExampleWorker(AbstractWorker):
 					left = polys.pop(minxi)
 		
 					# right is the rightest one
-					maxx = 0
+					maxx = float('-inf')
 					for i in range(len(polys)):
 						p = polys[i].boundingBox().xMaximum()
 						if p > maxx:


### PR DESCRIPTION
If a polygon has a vertex on a negative latitude or longitude, `splitPoly` would fail trying to find a maximum cut. Now it doesn't.